### PR TITLE
Fix negated patterns starting with /

### DIFF
--- a/lib/Text/Gitignore.pm
+++ b/lib/Text/Gitignore.pm
@@ -58,8 +58,7 @@ sub build_gitignore_matcher {
     my @patterns_re;
     foreach my $pattern (@$patterns) {
         if ( $pattern =~ m/^!/ ) {
-            my $re = $build_pattern->($pattern);
-            $re =~ s{^\\!}{};
+            my $re = $build_pattern->(substr $pattern, 1);
 
             push @patterns_re,
               {

--- a/t/negations.t
+++ b/t/negations.t
@@ -36,4 +36,11 @@ subtest 'negate any path' => sub {
     is_deeply \@matched, ['somewhere/there/else.js'];
 };
 
+subtest 'negate anchored at beginning' => sub {
+    my (@matched) = match_gitignore( [ '*.pm', '!/foo.pm' ],
+        'foo.pm', 'bar.pm' );
+
+    is_deeply \@matched, ['bar.pm'];
+};
+
 done_testing;


### PR DESCRIPTION
Before the patch, a negated pattern like `!/whatever` is turned into
`\\/whatever$` instead of `^whatever$`, which makes it fail.

Patch also adds a test for patch on negated patterns