### PR TITLE
Allow separation of "unmatched" and "excluded"

### DIFF
--- a/lib/Text/Gitignore.pm
+++ b/lib/Text/Gitignore.pm
@@ -80,7 +80,7 @@ sub build_gitignore_matcher {
     return sub {
         my $path = shift;
 
-        my $match = 0;
+        my $match = undef;
 
         foreach my $pattern (@patterns_re) {
             my $re = $pattern->{re};
@@ -93,7 +93,7 @@ sub build_gitignore_matcher {
                 }
             }
             else {
-                $match = !!( $path =~ m/$re/ );
+                $match = 1 if $path =~ m/$re/;
 
                 if ( $match && !@negatives ) {
                     return $match;
@@ -152,7 +152,28 @@ Returns matched paths (if any). Accepts a string (slurped file for example), or 
     }
 
 Returns a code reference. The produced function accepts a single file as a first parameter and returns true when it was
-matched.
+matched. In case no pattern is matched, it returns a false value with the following convention:
+
+=over
+
+=item *
+
+if the no-match reason is because of a negated pattern, then a false but defined value is returned (e.g. C<0>);
+
+=item *
+
+otherwise, if the no-match reason is that no I<direct> pattern matched, then C<undef> is returned.
+
+=back
+
+The use of different false values is inspired to the C<wantarray()> built-in function.
+
+Example:
+
+    my $matcher  = build_gitignore_matcher(['f*', '!foo*', 'foobar']);
+    my $matched  = $matcher->('foobar');  # $matched set to true
+    my $ignored  = $matcher->('bar');     # $ignored set to undef
+    my $excluded = $matcher->('foolish'); # $excluded set to false but defined (e.g. 0)
 
 =head1 LICENSE
 

--- a/t/falses.t
+++ b/t/falses.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Text::Gitignore qw(build_gitignore_matcher);
+
+my $matcher = build_gitignore_matcher(['f*', '!foo*', 'foobar']);
+
+subtest 'matched' => sub {
+    my $matched = $matcher->('foobar');
+    ok $matched;
+};
+
+subtest 'unmatched' => sub {
+    my $matched = $matcher->('bar');
+    ok ! defined($matched);
+};
+
+subtest 'excluded' => sub {
+    my $matched = $matcher->('foolish');
+    ok defined($matched) && !$matched;
+};
+
+done_testing;


### PR DESCRIPTION
This patch makes sure that the false values returned by
build_gitignore_matcher convey the additional informaton of whether the
input filename was simply ignored (i.e. not matched by any non-negated
pattern) or explicitly excluded (i.e. matched by a pattern).

This pull request implements a possible behavior to address Issue #4 - including a minimal test file and some additional documentation.

The introduced behavior is backwards-compatible.